### PR TITLE
add cleartext traffic manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <service
             android:name="vn.vhn.vhscode.CodeServerService"
             android:enabled="true"


### PR DESCRIPTION
Fix `net::ERRR_CLEARTEXT_NOT_PERMITTED` error when using `http://` url